### PR TITLE
Fix/ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=android-24
+    - ANDROID_TARGET=android-22
     - ANDROID_ABI=armeabi-v7a
     
 android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=android-22
+    - ANDROID_TARGET=google_apis-25
     - ANDROID_ABI=armeabi-v7a
     
 android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ android:
     - extra-google-m2repository
     
     # for instrumented tests
-    - $ANDROID_TARGET
-    - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
+    # - $ANDROID_TARGET
+    # - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
 
 before_install:
   - mkdir -p "$ANDROID_HOME/licenses" || true
@@ -41,11 +41,12 @@ before_script:
   # Grand permissions
   - chmod +x gradlew
   
-  - android list targets
-  - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI -c 100M    #Create AVD for given api
-  - emulator -avd test -no-skin -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
+  # for instrumented tests
+  # - android list targets
+  # - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI -c 100M    #Create AVD for given api
+  # - emulator -avd test -no-skin -no-audio -no-window &
+  # - android-wait-for-emulator
+  # - adb shell input keyevent 82 &
 
 script:
   - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=google_apis-25
+    - ANDROID_TARGET=android-24
     - ANDROID_ABI=armeabi-v7a
     
 android:
@@ -42,7 +42,7 @@ before_script:
   - chmod +x gradlew
   
   - android list targets
-  - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI    #Create AVD for given api
+  - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI -c 100M    #Create AVD for given api
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
   
   - touch $HOME/.android/repositories.cfg
   - yes | sdkmanager "platforms;android-28"
+  - yes | sdkmanager "build-tools;28.0.3"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ before_install:
   - mkdir -p "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
+  
+  - touch $HOME/.android/repositories.cfg
+  - yes | sdkmanager "platforms;android-28"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=android-28
+    - ANDROID_TARGET=android-27
     - ANDROID_ABI=armeabi-v7a
     
 android:
@@ -26,10 +26,6 @@ before_install:
   - mkdir -p "$ANDROID_HOME/licenses" || true
   - echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "$ANDROID_HOME/licenses/android-sdk-license"
   - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
-  
-  - touch $HOME/.android/repositories.cfg
-  - yes | sdkmanager "platforms;android-28"
-  - yes | sdkmanager "build-tools;28.0.3"
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ android:
     - extra-google-m2repository
     
     # for instrumented tests
-    # - $ANDROID_TARGET
-    # - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
+    - $ANDROID_TARGET
+    - sys-img-${ANDROID_ABI}-${ANDROID_TARGET}
 
 before_install:
   - mkdir -p "$ANDROID_HOME/licenses" || true
@@ -42,12 +42,12 @@ before_script:
   - chmod +x gradlew
   
   # for instrumented tests
-  # - android list targets
-  # - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI -c 100M    #Create AVD for given api
-  # - emulator -avd test -no-skin -no-audio -no-window &
-  # - android-wait-for-emulator
-  # - adb shell input keyevent 82 &
+  - android list targets
+  - echo no | android create avd --force --name test --target $ANDROID_TARGET --abi $ANDROID_ABI -c 100M    #Create AVD for given api
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
 
 script:
   - ./gradlew build
-  # - ./gradlew connectedAndroidTest
+  - ./gradlew connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ jdk: oraclejdk8
 env:
   global:
     - ANDROID_TARGET=android-28
-    - ANDROID_ABI=x86
+    - ANDROID_ABI=armeabi-v7a
     
 android:
   components:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-    - $HOME/.android/build-cacåhe
+    - $HOME/.android/build-cache
  
 before_script:
   # Grand permissions
@@ -50,4 +50,4 @@ before_script:
 
 script:
   - ./gradlew build
-  - ./gradlew connectedAndroidTest
+  # - ./gradlew connectedAndroidTest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=android-27
+    - ANDROID_TARGET=android-22
     - ANDROID_ABI=armeabi-v7a
     
 android:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ jdk: oraclejdk8
 
 env:
   global:
-    - ANDROID_TARGET=android-29
-    - ANDROID_ABI=armeabi-v7a
+    - ANDROID_TARGET=android-28
+    - ANDROID_ABI=x86
     
 android:
   components:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # FightPandemics Android
 
 [![Platform](https://img.shields.io/badge/platform-android-lightgrey.svg)](#)
+[![Build Status](https://travis-ci.org/FightPandemics/FightPandemics-android.svg?branch=development)](https://travis-ci.com/FightPandemics/FightPandemics-android)
+
 
 Android app for the [FightPandemics](https://fightpandemics.com/)
 


### PR DESCRIPTION
**What this PR does**:

Travis file was configured to create an android-29 emulator, but it's currently not supported.
The current stable version for emulator is still android-22.

Also, included the _build badge_ on README file.

Related to #8 
