### PR TITLE
feature/home-feed : Edit/Delete Post screens

### DIFF
--- a/home/src/main/res/color/button_delete_stroke.xml
+++ b/home/src/main/res/color/button_delete_stroke.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/fightPandemicsWhiteSmoke" android:state_pressed="false" />
+    <item android:color="@color/colorRed" android:state_pressed="true" />
+</selector>

--- a/home/src/main/res/color/button_delete_text.xml
+++ b/home/src/main/res/color/button_delete_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/textColorPrimary" android:state_pressed="false" />
+    <item android:color="@color/colorRed" android:state_pressed="true" />
+</selector>

--- a/home/src/main/res/color/button_delete_tint.xml
+++ b/home/src/main/res/color/button_delete_tint.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/fightPandemicsWhiteSmoke" android:state_pressed="false" />
+    <item android:color="@color/colorWhite" android:state_pressed="true" />
+</selector>

--- a/home/src/main/res/drawable/dialogue_background.xml
+++ b/home/src/main/res/drawable/dialogue_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    android:padding="10dp">
+    <solid android:color="@color/colorWhite" />
+    <corners android:radius="4dp" />
+    <stroke
+        android:color="@color/colorWhite"
+        android:width="1dp" />
+</shape>

--- a/home/src/main/res/drawable/dialogue_text_background.xml
+++ b/home/src/main/res/drawable/dialogue_text_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    android:padding="10dp">
+    <solid android:color="#b3282828" />
+    <corners android:radius="4dp" />
+</shape>

--- a/home/src/main/res/layout/delete_post_alert.xml
+++ b/home/src/main/res/layout/delete_post_alert.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/dialogue_background_transparent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="@dimen/dialogue_width_280dp"
+        android:layout_height="@dimen/dialogue_height_192dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="175dp"
+        android:background="@drawable/dialogue_background">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/delete_msg_title"
+            style="@style/AndroidNativeH216Px"
+            android:layout_width="@dimen/text_width_236dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="22dp"
+            android:lineSpacingExtra="0dp"
+            android:text="@string/delete_confirm_alert_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/delete_msg_content"
+            style="@style/AndroidNativeP114Px"
+            android:layout_width="@dimen/text_width_236dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="11dp"
+            android:text="@string/delete_confirm_alert_msg"
+            android:textColor="@color/fightPandemicsSuvaGrey"
+            app:layout_constraintEnd_toEndOf="@+id/delete_msg_title"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/delete_msg_title"
+            app:layout_constraintTop_toBottomOf="@+id/delete_msg_title" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/btn_cancel"
+            style="@style/textViewClickable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="119.5dp"
+            android:layout_marginTop="8dp"
+            android:paddingStart="4.5dp"
+            android:paddingTop="3dp"
+            android:paddingEnd="3.5dp"
+            android:paddingBottom="9dp"
+            android:text="@string/cancel"
+            android:textColor="@color/textColorPrimary"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/delete_msg_content" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/btn_delete"
+            style="@style/textViewClickable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16.5dp"
+            android:paddingStart="8.5dp"
+            android:paddingTop="3dp"
+            android:paddingEnd="8.5dp"
+            android:paddingBottom="9dp"
+            android:text="@string/delete"
+            android:textColor="@color/colorRed"
+            app:layout_constraintBottom_toBottomOf="@+id/btn_cancel"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/btn_cancel"
+            app:layout_constraintTop_toTopOf="@+id/btn_cancel" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/home/src/main/res/layout/delete_post_feedback.xml
+++ b/home/src/main/res/layout/delete_post_feedback.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="@dimen/dialogue_width_245dp"
+    android:layout_height="@dimen/dialogue_height_45dp"
+    android:layout_gravity="center_horizontal"
+    android:layout_marginTop="149dp"
+    android:background="@drawable/dialogue_text_background">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/tv_feedback_msg"
+        style="@style/AndroidNativeH314Px"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:text="@string/deleted_msg"
+        android:textColor="@color/colorWhite"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/home/src/main/res/layout/edit_delete_fragment.xml
+++ b/home/src/main/res/layout/edit_delete_fragment.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/bottom_sheet_height_154dp"
+    android:background="@drawable/bottom_nav_background">
+
+    <View
+        android:id="@+id/iv_pin_sheet"
+        android:layout_width="@dimen/button_width_50dp"
+        android:layout_height="@dimen/button_height_3.2dp"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/button_offering_background"
+        android:gravity="center_horizontal"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_edit_post"
+        style="@style/buttonEdit"
+        android:layout_width="@dimen/button_width_320dp"
+        android:layout_height="@dimen/button_height_45dp"
+        android:layout_marginTop="20.8dp"
+        android:text="@string/edit_post"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/iv_pin_sheet" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_delete_post"
+        style="@style/buttonDelete"
+        android:layout_width="@dimen/button_width_320dp"
+        android:layout_height="@dimen/button_height_45dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/delete_post"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_edit_post" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/home/src/main/res/values/colors.xml
+++ b/home/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="dialogue_background_transparent">#6b000000</color>
+</resources>

--- a/home/src/main/res/values/dimens.xml
+++ b/home/src/main/res/values/dimens.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Edit/Delete Post -->
+    <dimen name="dialogue_width_280dp">280dp</dimen>
+    <dimen name="dialogue_height_192dp">192dp</dimen>
+    <dimen name="bottom_sheet_height_154dp">154dp</dimen>
+    <dimen name="dialogue_width_245dp">245dp</dimen>
+    <dimen name="dialogue_height_45dp">45dp</dimen>
+    <dimen name="button_width_320dp">320dp</dimen>
+    <dimen name="button_height_45dp">45dp</dimen>
+    <dimen name="button_width_50dp">50dp</dimen>
+    <dimen name="button_height_3.2dp">3.2dp</dimen>
+    <dimen name="text_width_236dp">236dp</dimen>
+    
+</resources>

--- a/home/src/main/res/values/strings.xml
+++ b/home/src/main/res/values/strings.xml
@@ -13,4 +13,13 @@
     <string name="comments">Comments</string>
     <string name="share">Share</string>
 
+    <!--Edit Delete Post-->
+    <string name="edit_post">Edit Post</string>
+    <string name="delete_post">Delete Post</string>
+    <string name="deleted_msg">The post is deleted.</string>
+    <string name="delete_confirm_alert_title">Are you sure you want to delete post?</string>
+    <string name="delete_confirm_alert_msg">Once your post is deleted, it is gone forever and this action cannot be undone.</string>
+    <string name="cancel">Cancel</string>
+    <string name="delete">Delete</string>
+
 </resources>

--- a/home/src/main/res/values/styles.xml
+++ b/home/src/main/res/values/styles.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="buttonEdit" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="strokeColor">@color/fightPandemicsWhiteSmoke</item>
+        <item name="strokeWidth">1dp</item>
+        <item name="backgroundTint">@color/fightPandemicsWhiteSmoke</item>
+        <item name="android:fontFamily">@font/worksans_regular</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">@color/textColorPrimary</item>
+        <item name="android:textSize">15sp</item>
+    </style>
+
+    <style name="buttonDelete" parent="Widget.MaterialComponents.Button.OutlinedButton">
+        <item name="rippleColor">@null</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="strokeColor">@color/button_delete_stroke</item>
+        <item name="strokeWidth">1dp</item>
+        <item name="backgroundTint">@color/button_delete_tint</item>
+        <item name="android:fontFamily">@font/worksans_regular</item>
+        <item name="android:textAllCaps">false</item>
+        <item name="android:textColor">@color/button_delete_text</item>
+        <item name="android:textSize">15sp</item>
+    </style>
+
+    <style name="textViewClickable">
+        <item name="android:clickable">true</item>
+        <item name="android:focusable">true</item>
+        <item name="android:gravity">center</item>
+        <item name="android:letterSpacing">0.04</item>
+        <item name="android:textSize">16sp</item>
+    </style>
+</resources>


### PR DESCRIPTION
What this PR does:  **Create XML files for Edit/Delete Post screens**

Which issue(s) this PR fixes:

**Fixes #123**

Special notes for reviewers: fixing PR and try to fix code reviewed by @carl05 in https://github.com/FightPandemics/FightPandemics-android/pull/129

Additional comments: none


the designs: https://zpl.io/beQQAdB



**I'm testing button in runtime.**
**edit_delete_fragment.xml**  -   when delete button is pressed :

![cek1](https://user-images.githubusercontent.com/30503340/96601691-794c7d00-131c-11eb-93ef-964dde865ea7.png)

**edit_delete_fragment.xml**  -  when no button is pressed :

![cek2](https://user-images.githubusercontent.com/30503340/96601673-75205f80-131c-11eb-9e40-ab61de13c27a.png)



**delete_post_alert.xml**  :

![dialogue](https://user-images.githubusercontent.com/30503340/96601680-76518c80-131c-11eb-8f61-94ce1a0ea313.PNG)



**delete_post_feedback.xml**  :

![post_deleted](https://user-images.githubusercontent.com/30503340/96601687-7782b980-131c-11eb-82c2-72751d40819e.PNG)
